### PR TITLE
Client: fix PUT requests

### DIFF
--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -138,7 +138,7 @@ class Request
 	 */
 	public static function paymentReverse(array $data)
 	{
-		return new static(self::PUT, 'payment/reverse/:merchantId/:payId/:dttm/:signature', $data);
+		return new static(self::PUT, 'payment/reverse', $data);
 	}
 
 
@@ -149,7 +149,7 @@ class Request
 	 */
 	public static function paymentClose(array $data)
 	{
-		return new static(self::PUT, 'payment/close/:merchantId/:payId/:dttm/:signature', $data);
+		return new static(self::PUT, 'payment/close', $data);
 	}
 
 
@@ -160,7 +160,7 @@ class Request
 	 */
 	public static function paymentRefund(array $data)
 	{
-		return new static(self::PUT, 'payment/refund/:merchantId/:payId/:dttm/:signature', $data);
+		return new static(self::PUT, 'payment/refund', $data);
 	}
 
 


### PR DESCRIPTION
Data in PUT requests are passed in body and must not be in the URL. The paygate returns 404 otherwise.
