### PR TITLE
eAPI 1.6

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -5,6 +5,7 @@ This extension provides a client library for ČSOB Payment Gateway.
 
 - [CSOB payment gateway wiki](https://github.com/csob/paymentgateway/wiki)
 - [CSOB eAPI 1.5](https://github.com/csob/paymentgateway/wiki/eAPI-1.5)
+- [CSOB eAPI 1.6](https://github.com/csob/paymentgateway/wiki/eAPI-1.6)
 
 
 Installation

--- a/src/Client.php
+++ b/src/Client.php
@@ -237,6 +237,26 @@ class Client
 
 
 	/**
+	 * @return bool
+	 */
+	public function isRecurrentPaymentSupported()
+	{
+		return $this->config->getVersion() === Configuration::VERSION_1_5;
+	}
+
+
+
+	/**
+	 * @return bool
+	 */
+	public function isOneclickPaymentSupported()
+	{
+		return !$this->isRecurrentPaymentSupported();
+	}
+
+
+
+	/**
 	 * @param Payment $payment
 	 * @return Message\Response
 	 */
@@ -246,8 +266,8 @@ class Client
 			throw new InvalidArgumentException('The origPayId is required for recurrent payment.');
 		}
 
-		if ($this->config->getVersion() !== Configuration::VERSION_1_5) {
-			throw new NotSupportedException('payment/recurrent is only supported in eAPI v1.5');
+		if (!$this->isRecurrentPaymentSupported()) {
+			throw new NotSupportedException('payment/recurrent is not supported in currently used eAPI version');
 		}
 
 		$data = $payment->toArray();
@@ -268,8 +288,8 @@ class Client
 			throw new InvalidArgumentException('The origPayId is required for oneclick payment.');
 		}
 
-		if ($this->config->getVersion() === Configuration::VERSION_1_5) {
-			throw new NotSupportedException('payment/oneclick is only supported in eAPI since v1.6');
+		if (!$this->isOneclickPaymentSupported()) {
+			throw new NotSupportedException('payment/oneclick is not supported in currently used eAPI version');
 		}
 
 		$data = $payment->toArray();
@@ -286,8 +306,8 @@ class Client
 	 */
 	public function paymentOneclickStart($paymentId)
 	{
-		if ($this->config->getVersion() === Configuration::VERSION_1_5) {
-			throw new NotSupportedException('payment/oneclick is only supported in eAPI since v1.6');
+		if (!$this->isOneclickPaymentSupported()) {
+			throw new NotSupportedException('payment/oneclick is not supported in currently used eAPI version');
 		}
 
 		$data = [

--- a/src/Client.php
+++ b/src/Client.php
@@ -468,12 +468,12 @@ class Client
 	{
 		$endpoint = preg_replace_callback('~\\:(?P<name>[a-z0-9]+)~i', function ($m) use ($data) {
 			if (empty($data[$m['name']])) {
-				throw new InvalidArgumentException(sprintF('Missing key %s for the assembly of url', $m['name']));
+				throw new InvalidArgumentException(sprintf('Missing key %s for the assembly of url', $m['name']));
 			}
 			return urlencode($data[$m['name']]);
 		}, $endpoint);
 
-		return $this->config->getUrl() . '/' . $endpoint;
+		return $this->config->buildUrl() . '/' . $endpoint;
 	}
 
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -246,10 +246,57 @@ class Client
 			throw new InvalidArgumentException('The origPayId is required for recurrent payment.');
 		}
 
+		if ($this->config->getVersion() !== Configuration::VERSION_1_5) {
+			throw new NotSupportedException('payment/recurrent is only supported in eAPI v1.5');
+		}
+
 		$data = $payment->toArray();
 		$data['signature'] = $this->signature->signPayment($data);
 
 		return $this->processRequest(Message\Request::paymentRecurrent($data));
+	}
+
+
+
+	/**
+	 * @param Payment $payment
+	 * @return Message\Response
+	 */
+	public function paymentOneclickInit(Payment $payment)
+	{
+		if (!$payment->getOriginalPayId()) {
+			throw new InvalidArgumentException('The origPayId is required for oneclick payment.');
+		}
+
+		if ($this->config->getVersion() === Configuration::VERSION_1_5) {
+			throw new NotSupportedException('payment/oneclick is only supported in eAPI since v1.6');
+		}
+
+		$data = $payment->toArray();
+		$data['signature'] = $this->signature->signPayment($data);
+
+		return $this->processRequest(Message\Request::paymentOneclickInit($data));
+	}
+
+
+
+	/**
+	 * @param string $paymentId
+	 * @return Message\Response
+	 */
+	public function paymentOneclickStart($paymentId)
+	{
+		if ($this->config->getVersion() === Configuration::VERSION_1_5) {
+			throw new NotSupportedException('payment/oneclick is only supported in eAPI since v1.6');
+		}
+
+		$data = [
+			'merchantId' => $this->config->getMerchantId(),
+			'payId' => $paymentId,
+			'dttm' => $this->formatDatetime(),
+		];
+
+		return $this->processRequest(Message\Request::paymentOneclickStart($data));
 	}
 
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -20,8 +20,11 @@ namespace Kdyby\CsobPaymentGateway;
 class Configuration
 {
 
-	const DEFAULT_SANDBOX_URL = 'https://iapi.iplatebnibrana.csob.cz/api/v1.5';
-	const DEFAULT_PRODUCTION_URL = 'https://api.platebnibrana.csob.cz/api/v1.5';
+	const VERSION_1_5 = '1.5';
+	const VERSION_1_6 = '1.6';
+
+	const DEFAULT_SANDBOX_URL = 'https://iapi.iplatebnibrana.csob.cz/api';
+	const DEFAULT_PRODUCTION_URL = 'https://api.platebnibrana.csob.cz/api';
 
 	CONST DEFAULT_CSOB_SANDBOX_CERT = 'mips_iplatebnibrana.csob.cz.pub';
 	CONST DEFAULT_CSOB_PRODUCTION_CERT = 'mips_platebnibrana.csob.cz.pub';
@@ -30,6 +33,11 @@ class Configuration
 	 * @var string
 	 */
 	private $url = self::DEFAULT_SANDBOX_URL;
+
+	/**
+	 * @var string
+	 */
+	private $version = self::VERSION_1_5;
 
 	/**
 	 * @var string
@@ -71,6 +79,16 @@ class Configuration
 	public function getUrl()
 	{
 		return $this->url;
+	}
+
+
+
+	/**
+	 * @return string
+	 */
+	public function buildUrl()
+	{
+		return $this->url . '/v' . $this->version;
 	}
 
 
@@ -150,6 +168,32 @@ class Configuration
 		}
 
 		$this->returnMethod = $returnMethod;
+		return $this;
+	}
+
+
+
+	/**
+	 * @return string
+	 */
+	public function getVersion()
+	{
+		return $this->version;
+	}
+
+
+
+	/**
+	 * @param string $version
+	 * @return Configuration
+	 */
+	public function setVersion($version)
+	{
+		if (!in_array($version, [self::VERSION_1_5, self::VERSION_1_6], TRUE)) {
+			throw new InvalidArgumentException('Only 1.5 and 1.6 eAPI versions are supported');
+		}
+
+		$this->version = $version;
 		return $this;
 	}
 

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -180,6 +180,28 @@ class Request
 	 * @param array $data
 	 * @return Request
 	 */
+	public static function paymentOneclickInit(array $data)
+	{
+		return new static(self::POST, 'payment/oneclick/init', $data);
+	}
+
+
+
+	/**
+	 * @param array $data
+	 * @return Request
+	 */
+	public static function paymentOneclickStart(array $data)
+	{
+		return new static(self::POST, 'payment/oneclick/start', $data);
+	}
+
+
+
+	/**
+	 * @param array $data
+	 * @return Request
+	 */
 	public static function customerInfo(array $data)
 	{
 		return new static(self::GET, 'customer/info/:merchantId/:customerId/:dttm/:signature', $data);

--- a/src/Message/Signature.php
+++ b/src/Message/Signature.php
@@ -54,6 +54,9 @@ class Signature
 		'merchantData',
 		'customerId',
 		'language',
+		'ttlSec',
+		'logoVersion',
+		'colorSchemeVersion',
 	];
 
 	/**

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -167,6 +167,32 @@ class Payment
 	 */
 	private $language = self::LANGUAGE_CZ;
 
+	/**
+	 * Nastavení životnosti transakce, v sekundách, min. povolená hodnota 300, max. povolená
+	 * hodnota 1800 (5-30 min)
+	 *
+	 * @var int
+	 */
+	private $ttlSec;
+
+	/**
+	 * Verze schváleného loga obchodníka, které se pro danou transakci zobrazí. Pokud se bude jednat
+	 * o dosud neschválené logo, použije se aktivní logo obchodníka, pokud není, defaultní logo
+	 * platební brány
+	 *
+	 * @var int
+	 */
+	private $logoVersion;
+
+	/**
+	 * Verze schváleného barevného schématu obchodníka, které se pro danou transakci zobrazí. Pokud se
+	 * bude jednat o dosud neschválené barevné schéma, zobrazí se aktivní barevné schéma obchodníka,
+	 * pokud není, zobrazí se defaultní barevné schéma platební brány
+	 *
+	 * @var int
+	 */
+	private $colorSchemeVersion;
+
 
 
 	public function __construct($merchantId, $orderNo = NULL, $customerId = NULL)
@@ -408,6 +434,46 @@ class Payment
 
 
 	/**
+	 * @param int $ttlSec
+	 * @return Payment
+	 */
+	public function setTtlSec($ttlSec)
+	{
+		if ($ttlSec < 300 || $ttlSec > 1800) {
+			throw new InvalidArgumentException('The TTL has to be a numeric value between 300 and 1800');
+		}
+
+		$this->ttlSec = $ttlSec;
+		return $this;
+	}
+
+
+
+	/**
+	 * @param int $logoVersion
+	 * @return Payment
+	 */
+	public function setLogoVersion($logoVersion)
+	{
+		$this->logoVersion = $logoVersion;
+		return $this;
+	}
+
+
+
+	/**
+	 * @param int $colorSchemeVersion
+	 * @return Payment
+	 */
+	public function setColorSchemeVersion($colorSchemeVersion)
+	{
+		$this->colorSchemeVersion = $colorSchemeVersion;
+		return $this;
+	}
+
+
+
+	/**
 	 * Please note, that when you wanna provide 100.25 CZK,
 	 * you should pass here the number 10025
 	 *
@@ -551,6 +617,18 @@ class Payment
 		}
 
 		$data['language'] = $this->language;
+
+		if ($this->ttlSec !== NULL) {
+			$data['ttlSec'] = $this->ttlSec;
+		}
+
+		if ($this->logoVersion !== NULL) {
+			$data['logoVersion'] = $this->logoVersion;
+		}
+
+		if ($this->colorSchemeVersion !== NULL) {
+			$data['colorSchemeVersion'] = $this->colorSchemeVersion;
+		}
 
 		return $data;
 	}

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -34,6 +34,7 @@ class Payment
 
 	const OPERATION_PAYMENT = 'payment';
 	const OPERATION_PAYMENT_RECURRENT = 'recurrentPayment';
+	const OPERATION_PAYMENT_ONECLICK = 'oneclickPayment';
 
 	const PAY_METHOD_CARD = 'card';
 
@@ -311,7 +312,7 @@ class Payment
 	 */
 	public function setPayOperation($payOperation)
 	{
-		if (!in_array($payOperation, [self::OPERATION_PAYMENT, self::OPERATION_PAYMENT_RECURRENT], TRUE)) {
+		if (!in_array($payOperation, [self::OPERATION_PAYMENT, self::OPERATION_PAYMENT_RECURRENT, self::OPERATION_PAYMENT_ONECLICK], TRUE)) {
 			throw new InvalidArgumentException('Only Payment::OPERATION_* constants are allowed');
 		}
 

--- a/src/exceptions.php
+++ b/src/exceptions.php
@@ -35,6 +35,13 @@ class InvalidArgumentException extends \InvalidArgumentException implements Exce
 
 
 
+class NotSupportedException extends \LogicException implements Exception
+{
+
+}
+
+
+
 class UnexpectedValueException extends \UnexpectedValueException implements Exception
 {
 

--- a/tests/KdybyTests/CsobPaymentGateway/Client.paymentOneclick.phpt
+++ b/tests/KdybyTests/CsobPaymentGateway/Client.paymentOneclick.phpt
@@ -119,7 +119,7 @@ class ClientPaymentOneclickTest extends CsobTestCase
 
 		Assert::throws(function () use ($payment) {
 			$this->client->paymentOneclickInit($payment);
-		}, NotSupportedException::class, 'payment/oneclick is only supported in eAPI since v1.6');
+		}, NotSupportedException::class, 'payment/oneclick is not supported in currently used eAPI version');
 	}
 
 }

--- a/tests/KdybyTests/CsobPaymentGateway/Client.paymentOneclick.phpt
+++ b/tests/KdybyTests/CsobPaymentGateway/Client.paymentOneclick.phpt
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Client: payment/oneclick/*
+ *
+ * @testCase
+ */
+
+namespace KdybyTests\CsobPaymentGateway;
+
+use Kdyby\CsobPaymentGateway\Configuration;
+use Kdyby\CsobPaymentGateway\NotSupportedException;
+use Kdyby\CsobPaymentGateway\OperationNotAllowedException;
+use Kdyby\CsobPaymentGateway\Payment;
+use Kdyby\CsobPaymentGateway\PaymentNotFoundException;
+use Kdyby\CsobPaymentGateway\PaymentNotInValidStateException;
+use Tester;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+
+
+/**
+ * @author Jiří Pudil <me@jiripudil.cz>
+ */
+class ClientPaymentOneclickTest extends CsobTestCase
+{
+
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->configuration->setVersion(Configuration::VERSION_1_6);
+	}
+
+
+
+	public function testPaymentOneclick()
+	{
+		$payment = $this->client->createPayment(15000001)
+			->setOriginalPayId('4ff025effb8d5BD')
+			->setDescription('Test payment')
+			->setReturnUrl('https://kdyby.org/process-payment-response')
+			->addCartItem('Test item 1', 42 * 100, 1)
+			->addCartItem('Test item 2', 158 * 100, 2);
+
+		$initResponse = $this->client->paymentOneclickInit($payment);
+		Assert::notSame(NULL, $initResponse->getPayId());
+		Assert::same(0, $initResponse->getResultCode());
+		Assert::same('OK', $initResponse->getResultMessage());
+		Assert::same(Payment::STATUS_REQUESTED, $initResponse->getPaymentStatus());
+
+		$startResponse = $this->client->paymentOneclickStart($initResponse->getPayId());
+		Assert::same($initResponse->getPayId(), $startResponse->getPayId());
+		Assert::same(0, $startResponse->getResultCode());
+		Assert::same('OK', $startResponse->getResultMessage());
+		Assert::same(Payment::STATUS_PENDING, $startResponse->getPaymentStatus());
+	}
+
+
+
+	public function testPaymentOneclickNotAuthorized()
+	{
+		$payment = $this->client->createPayment(15000001)
+			->setOriginalPayId('6bc16c0ea9c25BD')
+			->setDescription('Test payment')
+			->setReturnUrl('https://kdyby.org/process-payment-response')
+			->addCartItem('Test item 1', 42 * 100, 1)
+			->addCartItem('Test item 2', 158 * 100, 2);
+
+		Assert::throws(function () use ($payment) {
+			$this->client->paymentOneclickInit($payment);
+		}, PaymentNotInValidStateException::class, 'orig payment not authorized');
+	}
+
+
+
+	public function testPaymentOneclickNotFound()
+	{
+		$payment = $this->client->createPayment(15000001)
+			->setOriginalPayId('nonExistentId')
+			->setDescription('Test payment')
+			->setReturnUrl('https://kdyby.org/process-payment-response')
+			->addCartItem('Test item 1', 42 * 100, 1)
+			->addCartItem('Test item 2', 158 * 100, 2);
+
+		Assert::throws(function () use ($payment) {
+			$this->client->paymentOneclickInit($payment);
+		}, PaymentNotFoundException::class, 'orig payment not found');
+	}
+
+
+
+	public function testPaymentOneclickNotATemplate()
+	{
+		$payment = $this->client->createPayment(15000001)
+			->setOriginalPayId('52b7b2f93846fBD')
+			->setDescription('Test payment')
+			->setReturnUrl('https://kdyby.org/process-payment-response')
+			->addCartItem('Test item 1', 42 * 100, 1)
+			->addCartItem('Test item 2', 158 * 100, 2);
+
+		Assert::throws(function () use ($payment) {
+			$this->client->paymentOneclickInit($payment);
+		}, OperationNotAllowedException::class, 'orig payment not oneclick payment template');
+	}
+
+
+
+	public function testPaymentOneclickNotSupportedIn15()
+	{
+		$this->configuration->setVersion(Configuration::VERSION_1_5);
+		$payment = $this->client->createPayment(15000001)
+			->setOriginalPayId('52b7b2f93846fBD')
+			->setDescription('Test payment')
+			->setReturnUrl('https://kdyby.org/process-payment-response')
+			->addCartItem('Test item 1', 42 * 100, 1)
+			->addCartItem('Test item 2', 158 * 100, 2);
+
+		Assert::throws(function () use ($payment) {
+			$this->client->paymentOneclickInit($payment);
+		}, NotSupportedException::class, 'payment/oneclick is only supported in eAPI since v1.6');
+	}
+
+}
+
+
+
+\run(new ClientPaymentOneclickTest());

--- a/tests/KdybyTests/CsobPaymentGateway/Client.paymentProcess.phpt
+++ b/tests/KdybyTests/CsobPaymentGateway/Client.paymentProcess.phpt
@@ -8,12 +8,8 @@
 
 namespace KdybyTests\CsobPaymentGateway;
 
-use Kdyby\CsobPaymentGateway\Client;
 use Kdyby\CsobPaymentGateway\Configuration;
-use Kdyby\CsobPaymentGateway\Http\GuzzleClient;
-use Kdyby\CsobPaymentGateway\InvalidParameterException;
 use Kdyby\CsobPaymentGateway\Message\RedirectResponse;
-use Kdyby\CsobPaymentGateway\Message\Signature;
 use Kdyby\CsobPaymentGateway\Payment;
 use Tester;
 use Tester\Assert;
@@ -44,7 +40,7 @@ class ClientPaymentProcessTest extends CsobTestCase
 
 		$processResponse = $this->client->paymentProcess($response->getPayId());
 		Assert::type(RedirectResponse::class, $processResponse);
-		Assert::match(Configuration::DEFAULT_SANDBOX_URL . '/payment/process/%A%', $processResponse->getUrl());
+		Assert::match(Configuration::DEFAULT_SANDBOX_URL . '/v%a%/payment/process/%A%', $processResponse->getUrl());
 	}
 
 }

--- a/tests/KdybyTests/CsobPaymentGateway/Client.paymentRecurrent.phpt
+++ b/tests/KdybyTests/CsobPaymentGateway/Client.paymentRecurrent.phpt
@@ -8,7 +8,9 @@
 
 namespace KdybyTests\CsobPaymentGateway;
 
+use Kdyby\CsobPaymentGateway\Configuration;
 use Kdyby\CsobPaymentGateway\InvalidParameterException;
+use Kdyby\CsobPaymentGateway\NotSupportedException;
 use Kdyby\CsobPaymentGateway\OperationNotAllowedException;
 use Kdyby\CsobPaymentGateway\Payment;
 use Kdyby\CsobPaymentGateway\PaymentNotFoundException;
@@ -104,6 +106,23 @@ class ClientPaymentRecurrentTest extends CsobTestCase
 		Assert::throws(function () use ($payment) {
 			$this->client->paymentRecurrent($payment);
 		}, InvalidParameterException::class, 'payment/recurrent amount exceeds origin payment amount');
+	}
+
+
+
+	public function testPaymentRecurrentNotSupportedIn16()
+	{
+		$this->configuration->setVersion(Configuration::VERSION_1_6);
+		$payment = $this->client->createPayment(15000001)
+			->setOriginalPayId('52b7b2f93846fBD')
+			->setDescription('Test payment')
+			->setReturnUrl('https://kdyby.org/process-payment-response')
+			->addCartItem('Test item 1', 42 * 100, 1)
+			->addCartItem('Test item 2', 158 * 100, 2);
+
+		Assert::throws(function () use ($payment) {
+			$this->client->paymentRecurrent($payment);
+		}, NotSupportedException::class, 'payment/recurrent is only supported in eAPI v1.5');
 	}
 
 }

--- a/tests/KdybyTests/CsobPaymentGateway/Client.paymentRecurrent.phpt
+++ b/tests/KdybyTests/CsobPaymentGateway/Client.paymentRecurrent.phpt
@@ -122,7 +122,7 @@ class ClientPaymentRecurrentTest extends CsobTestCase
 
 		Assert::throws(function () use ($payment) {
 			$this->client->paymentRecurrent($payment);
-		}, NotSupportedException::class, 'payment/recurrent is only supported in eAPI v1.5');
+		}, NotSupportedException::class, 'payment/recurrent is not supported in currently used eAPI version');
 	}
 
 }

--- a/tests/KdybyTests/CsobPaymentGateway/Client.paymentRecurrent.phpt
+++ b/tests/KdybyTests/CsobPaymentGateway/Client.paymentRecurrent.phpt
@@ -94,8 +94,6 @@ class ClientPaymentRecurrentTest extends CsobTestCase
 
 	public function testPaymentRecurrentExceedsOriginalAmount()
 	{
-		Tester\Environment::skip('Not yet sure how it should work');
-
 		$payment = $this->client->createPayment(15000001)
 			->setOriginalPayId('6a37894a1f822AK')
 			->setDescription('Test payment')

--- a/tests/KdybyTests/CsobPaymentGateway/Client.versioning.phpt
+++ b/tests/KdybyTests/CsobPaymentGateway/Client.versioning.phpt
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Client: versioning
+ *
+ * @testCase
+ */
+
+namespace KdybyTests\CsobPaymentGateway;
+
+use Kdyby\CsobPaymentGateway\Configuration;
+use Kdyby\CsobPaymentGateway\Message\RedirectResponse;
+use Kdyby\CsobPaymentGateway\Message\Response;
+use Kdyby\CsobPaymentGateway\Payment;
+use Tester;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+
+
+/**
+ * @author Jiří Pudil <me@jiripudil.cz>
+ */
+class ClientVersioningTest extends CsobTestCase
+{
+
+	public function testFunctional()
+	{
+		$this->configuration->setVersion(Configuration::VERSION_1_6);
+		$this->initPayment();
+	}
+
+
+
+	public function testDefaultVersionUrl()
+	{
+		$response = $this->initPayment();
+
+		$processResponse = $this->client->paymentProcess($response->getPayId());
+		Assert::type(RedirectResponse::class, $processResponse);
+		Assert::match(Configuration::DEFAULT_SANDBOX_URL . '/v1.5/payment/process/%A%', $processResponse->getUrl());
+	}
+
+
+
+	public function testForcedVersionUrl()
+	{
+		$this->configuration->setVersion(Configuration::VERSION_1_6);
+		$response = $this->initPayment();
+
+		$processResponse = $this->client->paymentProcess($response->getPayId());
+		Assert::type(RedirectResponse::class, $processResponse);
+		Assert::match(Configuration::DEFAULT_SANDBOX_URL . '/v1.6/payment/process/%A%', $processResponse->getUrl());
+	}
+
+
+
+	/**
+	 * @return Response
+	 */
+	private function initPayment()
+	{
+		$payment = $this->client->createPayment(15000001)
+			->setDescription('Test payment')
+			->setReturnUrl('https://kdyby.org/process-payment-response')
+			->addCartItem('Test item 1', 42 * 100, 1)
+			->addCartItem('Test item 2', 158 * 100, 2);
+
+		$response = $this->client->paymentInit($payment);
+		Assert::notSame(NULL, $response->getPayId());
+		Assert::same(0, $response->getResultCode());
+		Assert::same('OK', $response->getResultMessage());
+		Assert::same(Payment::STATUS_REQUESTED, $response->getPaymentStatus());
+
+		return $response;
+	}
+
+}
+
+
+
+\run(new ClientVersioningTest());

--- a/tests/KdybyTests/CsobPaymentGateway/CsobTestCase.php
+++ b/tests/KdybyTests/CsobPaymentGateway/CsobTestCase.php
@@ -19,13 +19,18 @@ class CsobTestCase extends Tester\TestCase
 	 */
 	protected $client;
 
+	/**
+	 * @var Configuration
+	 */
+	protected $configuration;
+
 
 
 	protected function setUp()
 	{
 		parent::setUp();
 		$this->client = new Client(
-			new Configuration('A1029DTmM7', 'Test shop'),
+			$this->configuration = new Configuration('A1029DTmM7', 'Test shop'),
 			$signature = \Mockery::mock(Signature::class, [
 				new PrivateKey(__DIR__ . '/../../../examples/keys/rsa_A1029DTmM7.key', NULL),
 				new PublicKey(Configuration::getCsobSandboxCertPath())

--- a/tests/KdybyTests/CsobPaymentGateway/HttpClientMock.php
+++ b/tests/KdybyTests/CsobPaymentGateway/HttpClientMock.php
@@ -74,15 +74,21 @@ class HttpClientMock implements IHttpClient
 
 		list(,,, $resource, $action) = explode('/', $path);
 		$endpoint = $resource . '/' . $action;
+		$decodedBody = json_decode($body, TRUE);
 
 		switch ($endpoint) {
 			case 'payment/init':
-				$decodedBody = json_decode($body, TRUE);
 				return __DIR__ . '/api-data/init_' . $decodedBody['merchantId'] . '_' . $decodedBody['orderNo'] . '.json';
 
 			case 'payment/recurrent':
-				$decodedBody = json_decode($body, TRUE);
 				return __DIR__ . '/api-data/recurrent_' . $decodedBody['merchantId'] . '_' . $decodedBody['origPayId'] . '.json';
+
+			case 'payment/oneclick':
+				if (explode('/', $path)[5] === 'init') {
+					return __DIR__ . '/api-data/oneclickInit_' . $decodedBody['merchantId'] . '_' . $decodedBody['origPayId'] . '.json';
+				} else {
+					return __DIR__ . '/api-data/oneclickStart_' . $decodedBody['merchantId'] . '_' . $decodedBody['payId'] . '.json';
+				}
 
 			case 'payment/close':
 			case 'payment/reverse':

--- a/tests/KdybyTests/CsobPaymentGateway/Payment.toArray.phpt
+++ b/tests/KdybyTests/CsobPaymentGateway/Payment.toArray.phpt
@@ -99,6 +99,47 @@ class PaymentToArrayTest extends Tester\TestCase
 
 
 
+	public function testPaymentWithTtlSec()
+	{
+		$payment = new Payment('A1029DTmM7', 15000001);
+		$payment->setDttm(new \DateTime('2015-11-11 12:00:00'));
+		$payment->setDescription('Test payment');
+		$payment->setReturnUrl('https://example.com/process-payment-response');
+
+		$payment->addCartItem('Test item 1', 4200, 1);
+		$payment->addCartItem('Test item 2', 15800, 2);
+
+		$payment->setTtlSec(600);
+
+		$data = $payment->toArray();
+		Assert::true(isset($data['ttlSec']));
+		Assert::same(600, $data['ttlSec']);
+	}
+
+
+
+	public function testPaymentWithLogoAndColorSchemeVersion()
+	{
+		$payment = new Payment('A1029DTmM7', 15000001);
+		$payment->setDttm(new \DateTime('2015-11-11 12:00:00'));
+		$payment->setDescription('Test payment');
+		$payment->setReturnUrl('https://example.com/process-payment-response');
+
+		$payment->addCartItem('Test item 1', 4200, 1);
+		$payment->addCartItem('Test item 2', 15800, 2);
+
+		$payment->setLogoVersion(1);
+		$payment->setColorSchemeVersion(2);
+
+		$data = $payment->toArray();
+		Assert::true(isset($data['logoVersion']));
+		Assert::same(1, $data['logoVersion']);
+		Assert::true(isset($data['colorSchemeVersion']));
+		Assert::same(2, $data['colorSchemeVersion']);
+	}
+
+
+
 	public function testEmptyCart()
 	{
 		$payment = new Payment('A1029DTmM7', 15000001);

--- a/tests/KdybyTests/CsobPaymentGateway/Payment.validation.phpt
+++ b/tests/KdybyTests/CsobPaymentGateway/Payment.validation.phpt
@@ -77,6 +77,17 @@ class PaymentValidationTest extends Tester\TestCase
 			$payment = new Payment('A1029DTmM7', 15000001);
 			$payment->setLanguage('ES');
 		}, Kdyby\CsobPaymentGateway\InvalidArgumentException::class, 'Only Payment::LANGUAGE_* constants are allowed');
+
+		// ttlSec
+		Assert::throws(function () {
+			$payment = new Payment('A1029DTmM7', 15000001);
+			$payment->setTtlSec(200);
+		}, Kdyby\CsobPaymentGateway\InvalidArgumentException::class, 'The TTL has to be a numeric value between 300 and 1800');
+
+		Assert::throws(function () {
+			$payment = new Payment('A1029DTmM7', 15000001);
+			$payment->setTtlSec(2000);
+		}, Kdyby\CsobPaymentGateway\InvalidArgumentException::class, 'The TTL has to be a numeric value between 300 and 1800');
 	}
 
 

--- a/tests/KdybyTests/CsobPaymentGateway/api-data/oneclickInit_A1029DTmM7_4ff025effb8d5BD.json
+++ b/tests/KdybyTests/CsobPaymentGateway/api-data/oneclickInit_A1029DTmM7_4ff025effb8d5BD.json
@@ -1,0 +1,46 @@
+{
+	"status": 200,
+	"headers": {
+		"Server": [
+			"nginx"
+		],
+		"Date": [
+			"Fri, 29 Apr 2016 11:57:32 GMT"
+		],
+		"Content-Type": [
+			"application\/json;charset=UTF-8"
+		],
+		"Transfer-Encoding": [
+			"chunked"
+		],
+		"Connection": [
+			"keep-alive"
+		],
+		"Cache-Control": [
+			"no-cache, no-store, must-revalidate"
+		],
+		"Expires": [
+			"0"
+		],
+		"Pragma": [
+			"no-cache"
+		],
+		"Set-Cookie": [
+			"BIGipServerasors_iplatebnibrana.csob.cz_6443_pool=HTD8uGngvI9zIPdztSMfRlE092AOeDk5Y72UIwElYBjkrNCRsehkXeQtmfa0mIBHm\/TGMO9iZ3fM3bAAAAAB;secure; path=\/"
+		]
+	},
+	"body": {
+		"payId": "2e02060639547BD",
+		"dttm": {
+			"date": "2016-04-29 13:57:32.000000",
+			"timezone_type": 3,
+			"timezone": "UTC"
+		},
+		"resultCode": 0,
+		"resultMessage": "OK",
+		"paymentStatus": 1,
+		"authCode": null,
+		"merchantData": null,
+		"signature": "oDEtqVUNaOj1U4aZSoGW80j7VcGS4wdgiJ6cvmItQ9/tTyuPzuG77HEor3IRm0WoK5xRoFCnjV6B3Ot/kA8kAk04x4mAukZva482It2bNqbVn/iFy9NW7D9JT2B3yg0EBKNjWVE78qbPFlEbfig/Ko68aqdJplgksknDsRmwxh3GLBaq3z7ARhik65Fplz5s+Zf1ZOK+038jWlKzasTytYUIjomIk/7fBfd7eOG11kmdJbT9TnaenA3RFJz0znIEJeSbMPp9KyQZdv/85T16EzDNQ9UYHDKGu5DcCHvljurWsPB0Fyj4i4bvfpM0gAvWo64v23igBtSIMxIk8i/kQg=="
+	}
+}

--- a/tests/KdybyTests/CsobPaymentGateway/api-data/oneclickInit_A1029DTmM7_52b7b2f93846fBD.json
+++ b/tests/KdybyTests/CsobPaymentGateway/api-data/oneclickInit_A1029DTmM7_52b7b2f93846fBD.json
@@ -1,0 +1,39 @@
+{
+    "status": 200,
+    "headers": {
+        "Server": [
+            "nginx"
+        ],
+        "Date": [
+            "Fri, 29 Apr 2016 12:21:19 GMT"
+        ],
+        "Content-Type": [
+            "application\/json;charset=UTF-8"
+        ],
+        "Transfer-Encoding": [
+            "chunked"
+        ],
+        "Connection": [
+            "keep-alive"
+        ],
+        "Cache-Control": [
+            "no-cache, no-store, must-revalidate"
+        ],
+        "Expires": [
+            "0"
+        ],
+        "Pragma": [
+            "no-cache"
+        ],
+        "Set-Cookie": [
+            "BIGipServerasors_iplatebnibrana.csob.cz_6443_pool=wd2IhgSiET5X9z\/jBKM\/0wuNmVa8yw+ipW\/7INbkptfjpThn6V1PrOqKoVqfshhoyVlHt5Jirq97eTMAAAAB;secure; path=\/"
+        ]
+    },
+    "body": {
+        "dttm": "20160429142119",
+        "signature": "N2dEcL\/Y9a01V9UsO\/UJp3l9qRwuIcKKa82uyA8A1LaxCkj5h4BokBbjgnX7cngNIYKf2dzzhLjc5uQyDFmFVMeRW+DfBtsKNVHvkKjtRhTWCc1v\/FgmXFm3dEDzFjx4wmKICTs2dOLca2aDFJ\/l2YFt4d5C7QN4rC3dxcoOK8j4k1sdGqZ13y\/xb\/7CVZNw26VS1a19MHn1a3N+DucvgeqRJkxD4ZyiG\/7QILxrMyUwrzy9GTuwiaxbYm0qbKFYhIhU7YTogwgkypLiN7iMGH+4+Xw7qiyAOwAoE4BUCFEqzcsDWvLcpTPKDwx6jMRo87hjSKwjkSFRRWL0\/9+7Jg==",
+        "payId": "30a25b22abb9bBD",
+        "resultCode": 180,
+        "resultMessage": "orig payment not oneclick payment template"
+    }
+}

--- a/tests/KdybyTests/CsobPaymentGateway/api-data/oneclickInit_A1029DTmM7_6bc16c0ea9c25BD.json
+++ b/tests/KdybyTests/CsobPaymentGateway/api-data/oneclickInit_A1029DTmM7_6bc16c0ea9c25BD.json
@@ -1,0 +1,39 @@
+{
+    "status": 200,
+    "headers": {
+        "Server": [
+            "nginx"
+        ],
+        "Date": [
+            "Fri, 29 Apr 2016 12:19:08 GMT"
+        ],
+        "Content-Type": [
+            "application\/json;charset=UTF-8"
+        ],
+        "Transfer-Encoding": [
+            "chunked"
+        ],
+        "Connection": [
+            "keep-alive"
+        ],
+        "Cache-Control": [
+            "no-cache, no-store, must-revalidate"
+        ],
+        "Expires": [
+            "0"
+        ],
+        "Pragma": [
+            "no-cache"
+        ],
+        "Set-Cookie": [
+            "BIGipServerasors_iplatebnibrana.csob.cz_6443_pool=Fl9Y2YysOma7qu7jBKM\/0wuNmVa8y+FljWyYadVSJ\/kImi3+s2l7ORJjseLAo\/fPQsXtdj2WzNTJj1AAAAAB;secure; path=\/"
+        ]
+    },
+    "body": {
+        "dttm": "20160429141908",
+        "signature": "kUS5M+hxaNUU3aq1vP5H5\/KRnrU\/nLp0nfJn1rN0XukkL2R8QSq\/x5vg8epzc0yayBVaAImQFIjrMJf9xfPJoyPJk06EpR1YZIcfg2ZOFWKBgdzXPeICwgQ+yoDFQt4g2gvP5GQXp4z25AU4Bud7aHkNEKEDW6RKtdYNMPF+ih1hln1jd++V4LVaRWUZNbPI1xzCSfl3YO5UXlhK8jw0n5AxYzmhvciHntAx9S4RG8cgC2H+aM9TYy48aIRtqMEaKDDgzuqdtAch2D+AQ07Sps\/EY4vUwH+nZmEZWcLkE5RDQHdC\/CPQk1HO8YanIsEi5mcIino2ydcZgU\/QY3t+0w==",
+        "payId": "2a04b4c845738BD",
+        "resultCode": 150,
+        "resultMessage": "orig payment not authorized"
+    }
+}

--- a/tests/KdybyTests/CsobPaymentGateway/api-data/oneclickInit_A1029DTmM7_nonExistentId.json
+++ b/tests/KdybyTests/CsobPaymentGateway/api-data/oneclickInit_A1029DTmM7_nonExistentId.json
@@ -1,0 +1,39 @@
+{
+    "status": 200,
+    "headers": {
+        "Server": [
+            "nginx"
+        ],
+        "Date": [
+            "Fri, 29 Apr 2016 12:19:50 GMT"
+        ],
+        "Content-Type": [
+            "application\/json;charset=UTF-8"
+        ],
+        "Transfer-Encoding": [
+            "chunked"
+        ],
+        "Connection": [
+            "keep-alive"
+        ],
+        "Cache-Control": [
+            "no-cache, no-store, must-revalidate"
+        ],
+        "Expires": [
+            "0"
+        ],
+        "Pragma": [
+            "no-cache"
+        ],
+        "Set-Cookie": [
+            "BIGipServerasors_iplatebnibrana.csob.cz_6443_pool=HLBF7qXDPDPPMErjBKM\/0wuNmVa8y8kouZO1FAnbYT1JhYiUfn6Ty1VOrSQ5rdz4sTAxKIRpnD4OQjAAAAAB;secure; path=\/"
+        ]
+    },
+    "body": {
+        "dttm": "20160429141950",
+        "signature": "OpkQMCiJg6kXy2QJr9KNYOnE1y1gRaszI3zsIq9CIWoGblhdWLrVp++\/DF3\/BZzD\/PL1+HXV0adEVZtx53Ob1D5\/R7CTxVDywc5J\/a\/ZxSJY8szesKPeWV6tmnksRdCmmBj\/GDwHoUMuF8Uu5gJ1aOL3Xa\/uZg40xgCApy1K7eB2lSbIDZzXrNMSMiv4F+bgLa3uYuCKWxLgkBs2uqb\/JMp21Vz+7Vtd+wR+ZJXvQbr7N8jYAEZqN\/C4ae140Hs6fzPjFs19tGfMKZ9U\/bHDpR5Xv4NKEZHSMjyDLOBYKo+QolBF+voinpWCzU681EkTcU6sk7KAKvVNbgRqPTUZGg==",
+        "payId": "a5a5cc3d030f0BD",
+        "resultCode": 140,
+        "resultMessage": "orig payment not found"
+    }
+}

--- a/tests/KdybyTests/CsobPaymentGateway/api-data/oneclickStart_A1029DTmM7_2e02060639547BD.json
+++ b/tests/KdybyTests/CsobPaymentGateway/api-data/oneclickStart_A1029DTmM7_2e02060639547BD.json
@@ -1,0 +1,40 @@
+{
+    "status": 200,
+    "headers": {
+        "Server": [
+            "nginx"
+        ],
+        "Date": [
+            "Fri, 29 Apr 2016 12:08:17 GMT"
+        ],
+        "Content-Type": [
+            "application\/json;charset=UTF-8"
+        ],
+        "Transfer-Encoding": [
+            "chunked"
+        ],
+        "Connection": [
+            "keep-alive"
+        ],
+        "Cache-Control": [
+            "no-cache, no-store, must-revalidate"
+        ],
+        "Expires": [
+            "0"
+        ],
+        "Pragma": [
+            "no-cache"
+        ],
+        "Set-Cookie": [
+            "BIGipServerasors_iplatebnibrana.csob.cz_6443_pool=T9QXo9JazfMqhH3jBKM\/0wuNmVa8y7KwwA18Lx9cCQVr86JNw6tUEA9eKOYtX7LSMxyV9P2HRSSK5sgAAAAB;secure; path=\/"
+        ]
+    },
+    "body": {
+        "dttm": "20160429140817",
+        "signature": "tRYSeOx3GyyNw0cJNrhQ9CJSwuQemZhs5RMQnQFjk42pBrCqFh8LiQX8GCG5GvsBhtfvhT\/e8dCFfeIK\/gAkRRcd7111XSo94Zqw1IS1Bft3jSSu2z5KFf5n9fYZdYE8d3MBDmGPawYPk4P9yUAVBeIkVr+ORsI2ZlWwQh3s\/oY9yS0MS9gS8pmvfRsM9zbLcrpZsgpPMzx\/XwR2p\/hnU0JjqWOiWv4NA3YVU5Y8mq1P+u\/VpeLQkzDf\/jzy4VEEKmnZLPYeXP3Rqv1xS\/WTxZOUwYVhyUbyoHU3GWNku4SlH0KbQYQeu0Y3NVHt9pdY\/038KWEaHVSA\/b+LPAESzQ==",
+        "payId": "2e02060639547BD",
+        "resultCode": 0,
+        "resultMessage": "OK",
+        "paymentStatus": 2
+    }
+}

--- a/tests/KdybyTests/CsobPaymentGateway/api-data/status_A1029DTmM7_ee4c7266dca71AK.json
+++ b/tests/KdybyTests/CsobPaymentGateway/api-data/status_A1029DTmM7_ee4c7266dca71AK.json
@@ -5,7 +5,7 @@
             "nginx"
         ],
         "Date": [
-            "Thu, 12 Nov 2015 12:43:58 GMT"
+            "Fri, 29 Apr 2016 12:48:41 GMT"
         ],
         "Content-Type": [
             "application\/json;charset=UTF-8"
@@ -26,15 +26,23 @@
             "no-cache"
         ],
         "Set-Cookie": [
-            "BIGipServerasors_iplatebnibrana.csob.cz_6443_pool=E44iQqtggMgHMFdztSMfRlE092AOeFxX2ZNILTqpXPDEX457RObv3nrqP2nObAQ\/XkfywXW\/njTXDFUAAAAB;secure; path=\/"
+            "BIGipServerasors_iplatebnibrana.csob.cz_6443_pool=XUIg377\/mydVCMfjBKM\/0wuNmVa8y7Jaa6cxmRxMk++Wc4tRbAXJmH8AqNlEbuvPYpm3qKFakpxCewMAAAAB;secure; path=\/"
         ]
     },
     "body": {
-        "dttm": "20151112134358",
-        "signature": "qraOG01lNZeuSaoFfiBwjqViF2TAAs9AHLtXl2wi3vS0U2UgzKcdkChLp6LI6C6g\/3GV+yWRWi7csWeo87IMVp\/NHZxo3q2YPnNHyWVyI9doRsNMnU3YYcOTc\/o+DnlAV64j62LjPJIda8lrv6rYPaED2B\/olYzMJpBL7rr8jViu8ki6gRc4pshOTdpHOLCIW\/A3B6r3MmaZ7xi5asuI+FkRcnIy46\/aw2uqtqSuY7EuUqyBYaS9Gz1xHjnSrpe5Q5Y9lN8fTHIa3dfMGVEAGlH8iCipLxiioamV\/n4TWxtvukkEjKoY2HuiDZEkLJXE5\/RZUf2Lm6HpuzM+hCNffQ==",
+        "dttm": "20160429144841",
+        "signature": "lk2ZTm3GLa0ha0lGKag5WfH3YdwSjItxEe87CZFk28h4A+h4eDKo02Jn9o0WPCC84h84kMA1yni2TevaU0JcVRCfjqUUSMGQZXgIItPF2r+PvhnobOG0UiBxGkCheCr7TdSdZTQYVmIrqSyGUeNUufcFKJ41xpwALci7lvfgF4E91YztX\/j8kAoYU9r7bP41DpnslV+7dM1ZcncTVOwUGr\/BzSm2Og7IQe\/XxYrJQrxbwpLMQXv2IFvPXR07fnD5fv1ZwqzoRCDIjZrTthLgAT95yz263Woz+KQqMyDMQmnSY\/t4ooEND82MSLWAblPj\/m4RUOrZKBcKMVxvVAB05Q==",
         "payId": "ee4c7266dca71AK",
         "resultCode": 0,
         "resultMessage": "OK",
-        "paymentStatus": 1
+        "paymentStatus": 1,
+        "extensions": [
+            {
+                "dttm": "20160429144841",
+                "signature": "S93rULIRplMkbfg1736Dn3Ezb2hUGVEPW3Bo5j8aVqH4WgGcHk6R6gUo4DAzjQTXk+uix2v3uSczHcB0Eo+g1uzIYOQs5MWZhjEGuWHxgasTHYVhrRVa9eYp\/stkhjHqnRVBwQYEZg+ADMy6Wn7CCSzvFhHXBxTrVRnOT9qDgktLDB0ikTFn0ffkSe35zkOM06nA2BhwQ0g6QHnx27KuJ8K0RPcb75LrP\/mHAkZqWBtILiMOMdynUJAT3HDCe4c7cBUGUryZem4GBpxsmdCds3P48e8uYIBlQ6fsHEgJw9EW0OB50hXXb+YHMA0k6Z+OqGpCzT8J7GGcrw86YRwx6A==",
+                "extension": "trxDates",
+                "createdDate": "2015-11-12T13:42:37.793Z"
+            }
+        ]
     }
 }


### PR DESCRIPTION
see https://github.com/csob/paymentgateway/wiki/eAPI-1.6
- [x] option to choose which version to use
- [x] changes in `payment/init`
  - `language` is required (not affected)
  - added `ttlSec`, `logoVersion`, and `colorSchemeVersion`
- [x] `payment/oneclick` as a replacement for `payment/recurrent`
- [ ] extensions - might require more research (and honestly is not a priority) - maybe resolve in another pull request so that it does not block this one?
- [x] tag new release? What should be the version number? I'd vote for 2.0 since dropping paymentRecurrent altogether is a massive BC break
